### PR TITLE
Link to page explaining atomic CSS-in-JS

### DIFF
--- a/packages/docs/src/pages/atomic-css.mdx
+++ b/packages/docs/src/pages/atomic-css.mdx
@@ -9,7 +9,6 @@ order: 99
 Compiled uses atomic CSS as the delivery mechanism for your styles.
 However when writing your CSS-in-JS you won't even notice that it does!
 
-
 This page goes over what behaviors are possible using atomic CSS.
 If you're just getting started don't feel the need to read this page,
 but if you're interested in understanding more under the hood,

--- a/packages/docs/src/pages/atomic-css.mdx
+++ b/packages/docs/src/pages/atomic-css.mdx
@@ -7,7 +7,8 @@ order: 99
 # Atomic CSS
 
 Compiled uses atomic CSS as the delivery mechanism for your styles.
-However when writing [atomic CSS-in-JS](https://sebastienlorber.com/atomic-css-in-js) you won't even notice that it does!
+However when writing your CSS-in-JS you won't even notice that it does!
+
 
 This page goes over what behaviors are possible using atomic CSS.
 If you're just getting started don't feel the need to read this page,
@@ -172,3 +173,8 @@ At scale this can prove to be worth it,
 with compression techniques like `gzip` working very well at keeping your bundle size small.
 
 We have some [optimization ideas to investigate](https://github.com/atlassian-labs/compiled/issues/335) when we are further through development.
+
+## Resources
+
+- [Atomic CSS-in-JS](https://sebastienlorber.com/atomic-css-in-js)
+

--- a/packages/docs/src/pages/atomic-css.mdx
+++ b/packages/docs/src/pages/atomic-css.mdx
@@ -7,7 +7,7 @@ order: 99
 # Atomic CSS
 
 Compiled uses atomic CSS as the delivery mechanism for your styles.
-However when writing your CSS-in-JS you won't even notice that it does!
+However when writing [atomic CSS-in-JS](https://sebastienlorber.com/atomic-css-in-js) you won't even notice that it does!
 
 This page goes over what behaviors are possible using atomic CSS.
 If you're just getting started don't feel the need to read this page,

--- a/packages/docs/src/pages/atomic-css.mdx
+++ b/packages/docs/src/pages/atomic-css.mdx
@@ -173,7 +173,10 @@ with compression techniques like `gzip` working very well at keeping your bundle
 
 We have some [optimization ideas to investigate](https://github.com/atlassian-labs/compiled/issues/335) when we are further through development.
 
-## Resources
+## Other resources
 
 - [Atomic CSS-in-JS](https://sebastienlorber.com/atomic-css-in-js)
+- [The Shorthand-Longhand Problem in Atomic CSS](https://weser.io/blog/the-shorthand-longhand-problem-in-atomic-css)
+- [Why I Love Tailwind](https://mxstbr.com/thoughts/tailwind/)
+- 
 


### PR DESCRIPTION
Hi,

FYI I've wrote a blog post about atomic css-in-js and maintain a list of atomic css-in-js libs (including Compiled).
https://sebastienlorber.com/atomic-css-in-js

I thought adding a link in your doc here could be helpful for your users.
(no strong feelings if you don't agree, just a suggestion)