### PR TITLE
Typo in atomic-css.mdx

### DIFF
--- a/packages/docs/src/pages/atomic-css.mdx
+++ b/packages/docs/src/pages/atomic-css.mdx
@@ -178,5 +178,3 @@ We have some [optimization ideas to investigate](https://github.com/atlassian-la
 - [Atomic CSS-in-JS](https://sebastienlorber.com/atomic-css-in-js)
 - [The Shorthand-Longhand Problem in Atomic CSS](https://weser.io/blog/the-shorthand-longhand-problem-in-atomic-css)
 - [Why I Love Tailwind](https://mxstbr.com/thoughts/tailwind/)
-- 
-


### PR DESCRIPTION
There's an extra bulletpoint that I missed here.

![image](https://user-images.githubusercontent.com/749374/105374996-96893400-5c08-11eb-9a6d-e257cf74617c.png)
