### PR TITLE
fix: added missing prop on example

### DIFF
--- a/packages/docs/src/examples/css-prop.tsx
+++ b/packages/docs/src/examples/css-prop.tsx
@@ -125,7 +125,7 @@ export const CssPropConditionalRules = () => {
         require('!!raw-loader!@compiled/website-examples/dist/js/css-prop-conditional-rules.js')
           .default
       }>
-      <cssProp.CssPropConditionalRules>Arrange</cssProp.CssPropConditionalRules>
+      <cssProp.CssPropConditionalRules primary>Arrange</cssProp.CssPropConditionalRules>
     </Example>
   );
 };


### PR DESCRIPTION
The example on https://compiledcssinjs.com/docs/api-css-prop#conditional-rules is not rendered as expected.
Lozenge should have pink borders and text instead of blue

![image](https://user-images.githubusercontent.com/14813563/150433616-645f0c7a-73e9-4884-95d7-c358b9f1a175.png)

**How it is**
![image](https://user-images.githubusercontent.com/14813563/150433490-1545dbbe-8319-4d36-8212-3f4a2016704a.png)

**How it should be**
![image](https://user-images.githubusercontent.com/14813563/150433562-da320761-7a41-4e62-81c0-745c5217a970.png)
