### PR TITLE
Fix usages of parcel transformer to use config

### DIFF
--- a/packages/docs/src/pages/installation.mdx
+++ b/packages/docs/src/pages/installation.mdx
@@ -59,12 +59,12 @@ npm install @compiled/parcel-config --save-dev
 ```
 
 Add the compiled preset to your [Parcel config](https://v2.parceljs.org/configuration/plugin-configuration/).
-Make sure this is defined before other parcel configurations so that it runs first.
 
 ```json
 {
-  "extends": ["...", "@compiled/parcel-config"]
+  "extends": ["@parcel/config-default", "@compiled/parcel-config"]
 }
+```
 
 See the [configuration package docs](/pkg-parcel-config) for configuration options.
 

--- a/packages/docs/src/pages/installation.mdx
+++ b/packages/docs/src/pages/installation.mdx
@@ -58,7 +58,7 @@ Install the [Parcel v2](https://v2.parceljs.org) configuration.
 npm install @compiled/parcel-config --save-dev
 ```
 
-Add the compiled preset to your [Parcel config](https://v2.parceljs.org/configuration/plugin-configuration/).
+Add the compiled preset to your [Parcel config](https://parceljs.org/features/plugins/).
 
 ```json
 {

--- a/packages/docs/src/pages/installation.mdx
+++ b/packages/docs/src/pages/installation.mdx
@@ -55,7 +55,7 @@ See the [loader package docs](/pkg-webpack-loader) for configuration options.
 Install the [Parcel v2](https://v2.parceljs.org) configuration.
 
 ```bash
-npm install @compiled/parcel-transformer --save-dev
+npm install @compiled/parcel-config --save-dev
 ```
 
 Add the compiled preset to your [Parcel config](https://v2.parceljs.org/configuration/plugin-configuration/).

--- a/packages/docs/src/pages/pkg-parcel-config.mdx
+++ b/packages/docs/src/pages/pkg-parcel-config.mdx
@@ -16,7 +16,7 @@ import { Lozenge, HorizontalStack } from '@compiled/website-ui';
 See [installation](/installation#parcel) for setup instructions.
 
 ```bash
-npm install @compiled/parcel-transformer --save-dev
+npm install @compiled/parcel-config --save-dev
 ```
 
 ## Options


### PR DESCRIPTION
Updating some missed usages of the parcel transformer in examples. We should be recommending the config now (even though the transformer will work).