### PR TITLE
Fix casing in GitHub

### DIFF
--- a/packages/ui/src/layout/root.tsx
+++ b/packages/ui/src/layout/root.tsx
@@ -67,9 +67,9 @@ export const RootLayout = ({
               <Text variant="aside">Documentation</Text>
             </Link>
             <Link
-              title="Github"
+              title="GitHub"
               href="https://github.com/atlassian-labs/compiled">
-              <Text variant="aside">Github</Text>
+              <Text variant="aside">GitHub</Text>
             </Link>
           </HorizontalStack>
         </nav>


### PR DESCRIPTION
Hi there, thanks for Compiled, is a great library that we're considering to teach instead of Emotion in future Web Development Bootcamp cohorts at [upleveled.io](https://upleveled.io) 🙌 (based on how well it integrates with Next.js)

Just a quick PR to fix the casing in GitHub in the header