### PR TITLE
docs: add styled object to styled API docs

### DIFF
--- a/packages/docs/src/pages/api-styled.mdx
+++ b/packages/docs/src/pages/api-styled.mdx
@@ -17,7 +17,12 @@ import {
 
 Create a component that styles a JSX element which comes with built-in behavior such as `ref` and `as` prop support.
 
-<StyledString />
+<StyledObj />
+
+> **Tagged template expressions** <br /> Tagged template expressions are supported but call expression syntax is preferred.
+> See the
+> [no-styled-tagged-template-expression eslint rule](https://github.com/atlassian-labs/compiled/tree/master/packages/eslint-plugin/src/rules/no-styled-tagged-template-expression)
+> for more details.
 
 ## Dynamic declarations
 


### PR DESCRIPTION
Given that using styled objects is the preferred approach as enforced by the eslint rule, I think we should demonstrate the API in the docs.

## Screenshot
<img width="724" alt="image" src="https://user-images.githubusercontent.com/33766083/199633317-f93147f2-b42b-49d7-9490-cb3df35093cb.png">

