### PR TITLE
Update frontpage code examples

### DIFF
--- a/packages/examples/src/class-names-button.tsx
+++ b/packages/examples/src/class-names-button.tsx
@@ -7,17 +7,19 @@ export const Button = ({ children }) => {
         children({
           className: css({
             border: 'none',
-            borderRadius: 3,
+            borderRadius: '3px',
             padding: '8px 10px',
             backgroundColor: '#6554C0',
             color: '#fff',
             fontWeight: 400,
-            fontFamily: 'arial',
-            fontSize: 14,
-            ':hover': {
+            fontFamily: 'Arial',
+            fontSize: '14px',
+
+            '&:hover': {
               backgroundColor: '#8777D9',
             },
-            ':active': {
+
+            '&:active': {
               backgroundColor: '#5243AA',
             },
           }),

--- a/packages/examples/src/css-prop-button.tsx
+++ b/packages/examples/src/css-prop-button.tsx
@@ -1,25 +1,31 @@
 /** @jsxImportSource @compiled/react */
 
+import { css } from '@compiled/react';
+
+const buttonStyles = css({
+  border: 'none',
+  borderRadius: '3px',
+  padding: '8px 10px',
+  backgroundColor: '#6554C0',
+  color: '#fff',
+  fontWeight: 400,
+  fontFamily: 'Arial',
+  fontSize: '14px',
+
+  '&:hover': {
+    backgroundColor: '#8777D9',
+  },
+
+  '&:active': {
+    backgroundColor: '#5243AA',
+  },
+});
+
 export const Button = ({ children }) => {
   return (
     <button
       type="button"
-      css={{
-        border: 'none',
-        borderRadius: 3,
-        padding: '8px 10px',
-        backgroundColor: '#6554C0',
-        color: '#fff',
-        fontWeight: 400,
-        fontFamily: 'arial',
-        fontSize: 14,
-        ':hover': {
-          backgroundColor: '#8777D9',
-        },
-        ':active': {
-          backgroundColor: '#5243AA',
-        },
-      }}>
+      css={buttonStyles}>
       {children}
     </button>
   );

--- a/packages/examples/src/styled-button.tsx
+++ b/packages/examples/src/styled-button.tsx
@@ -1,20 +1,20 @@
 import { styled } from '@compiled/react';
 
-export const Button = styled.button`
-  border: none;
-  border-radius: 3px;
-  padding: 8px 10px;
-  background-color: #6554c0;
-  color: #fff;
-  font-weight: 400;
-  font-family: arial;
-  font-size: 14px;
+export const Button = styled.button({
+  border: 'none',
+  borderRadius: '3px',
+  padding: '8px 10px',
+  backgroundColor: '#6554C0',
+  color: '#fff',
+  fontWeight: 400,
+  fontFamily: 'Arial',
+  fontSize: '14px',
 
-  :hover {
-    background-color: #8777d9;
-  }
+  '&:hover': {
+    backgroundColor: '#8777D9',
+  },
 
-  :active {
-    background-color: #5243aa;
-  }
-`;
+  '&:active': {
+    backgroundColor: '#5243AA',
+  },
+});

--- a/packages/landing/src/components/landing.tsx
+++ b/packages/landing/src/components/landing.tsx
@@ -70,23 +70,23 @@ const TabButton = (props: {
 };
 
 const CodeExamples = () => {
-  const [shown, setShown] = useState<'css' | 'styled' | 'cn'>('styled');
+  const [shown, setShown] = useState<'css' | 'styled' | 'cn'>('css');
 
   return (
     <div>
-      <TabButton
-        id="styled-tab"
-        aria-controls="styled-example"
-        isSelected={shown === 'styled'}
-        onClick={() => setShown('styled')}>
-        Styled
-      </TabButton>
       <TabButton
         id="css-tab"
         aria-controls="css-example"
         isSelected={shown === 'css'}
         onClick={() => setShown('css')}>
         CSS prop
+      </TabButton>
+      <TabButton
+        id="styled-tab"
+        aria-controls="styled-example"
+        isSelected={shown === 'styled'}
+        onClick={() => setShown('styled')}>
+        Styled
       </TabButton>
       <TabButton
         id="cn-tab"
@@ -96,18 +96,6 @@ const CodeExamples = () => {
         Class names
       </TabButton>
 
-      {shown === 'css' && (
-        <div id="css-example" role="tabpanel" aria-labelledby="css-tab">
-          <Example
-            codeBackground={codeBackground}
-            variant="fixed"
-            exampleCode="<Button>Button</Button>"
-            before={cssPropBefore}
-            after={cssPropAfter}>
-            <cssProp.Button>Button</cssProp.Button>
-          </Example>
-        </div>
-      )}
       {shown === 'styled' && (
         <div id="styled-example" role="tabpanel" aria-labelledby="styled-tab">
           <Example
@@ -117,6 +105,18 @@ const CodeExamples = () => {
             before={styledBefore}
             after={styledAfter}>
             <styledExamples.Button>Button</styledExamples.Button>
+          </Example>
+        </div>
+      )}
+      {shown === 'css' && (
+        <div id="css-example" role="tabpanel" aria-labelledby="css-tab">
+          <Example
+            codeBackground={codeBackground}
+            variant="fixed"
+            exampleCode="<Button>Button</Button>"
+            before={cssPropBefore}
+            after={cssPropAfter}>
+            <cssProp.Button>Button</cssProp.Button>
           </Example>
         </div>
       )}

--- a/packages/landing/src/pages/landing-content.mdx
+++ b/packages/landing/src/pages/landing-content.mdx
@@ -12,18 +12,19 @@ leveraging the language to create expressive & dynamic experiences.
 
 import { css } from '@compiled/react';
 
-// We recommend using `css` for statically defined
-// styles, and `style` for dynamically defined styles.
-const largeTextStyles = css({
-  fontSize: '48px',
-});
+export const LargeText = ({ color, children }) => {
+  const largeTextStyles = css({
+    fontSize: '48px',
+    color: color,
+  });
 
-export const LargeText = ({ color, children }) => (
-  <span
-    css={largeTextStyles} style={{ color }}>
-    {children}
-  </span>
-);
+  return (
+    <span
+      css={largeTextStyles}>
+      {children}
+    </span>
+  )
+};
 ```
 
 <!-- prettier-ignore -->

--- a/packages/landing/src/pages/landing-content.mdx
+++ b/packages/landing/src/pages/landing-content.mdx
@@ -10,12 +10,17 @@ leveraging the language to create expressive & dynamic experiences.
 ```jsx
 /** @jsxImportSource @compiled/react */
 
+import { css } from '@compiled/react';
+
+// We recommend using `css` for statically defined
+// styles, and `style` for dynamically defined styles.
+const largeTextStyles = css({
+  fontSize: '48px',
+});
+
 export const LargeText = ({ color, children }) => (
   <span
-    css={{
-      color: color,
-      fontSize: 48,
-    }}>
+    css={largeTextStyles} style={{ color }}>
     {children}
   </span>
 );

--- a/packages/landing/src/pages/landing-content.mdx
+++ b/packages/landing/src/pages/landing-content.mdx
@@ -12,15 +12,14 @@ leveraging the language to create expressive & dynamic experiences.
 
 import { css } from '@compiled/react';
 
+const largeTextStyles = css({ fontSize: '48px' });
+
 export const LargeText = ({ color, children }) => {
-  const largeTextStyles = css({
-    fontSize: '48px',
-    color: color,
-  });
+  const dynamicColorStyles = css({ color: color });
 
   return (
     <span
-      css={largeTextStyles}>
+      css={[largeTextStyles, dynamicColorStyles]}>
       {children}
     </span>
   )


### PR DESCRIPTION
Updating the frontpage code examples to reflect our current recommendations. I'll be linking to our front page as part of a blog post for internal atlassian developers, and so we want to make sure they don't get immediately confused.

There are _lots_ of things we could update/refresh in the documentation - I have deliberately restricted my changes to those that affect the frontpage, as I have other time-sensitive tasks to work on right now :eyes:

* Swap `css` and `styled` examples so that `css` is now first
* Change `styled` example from using template string notation to using object notation
* Use '&' before `:hover` and `:active` to bring ourselves in line with [CSS nesting](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_nesting/Using_CSS_nesting)

Before:

![image](https://github.com/compiled/website/assets/2908767/1dbe0738-f0f5-4b46-b32e-c5dd9c66008a)

After:

![image](https://github.com/compiled/website/assets/2908767/d050d8c5-833e-4544-af44-1e2597164cf0)
